### PR TITLE
Hint for urgency was not being sent anymore when urgency=0

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ class Notify extends EventEmitter {
       this.#config.hints['y'] = new Variant('i', hints.y);
     }
 
-    if ('urgency' in hints && typeAssert.integer(hints.urgency, 'hints.urgency is not integer.')) {
+    if ('urgency' in hints && typeAssert.integer(hints.urgency, 'hints.urgency is not integer.') != null) {
       // eslint-disable-next-line dot-notation
       this.#config.hints['urgency'] = new Variant('y', hints.urgency);
     }

--- a/index.js
+++ b/index.js
@@ -238,6 +238,11 @@ class Notify extends EventEmitter {
       this.#config.hints['transient'] = new Variant('b', hints.transient);
     }
 
+    if ('value' in hints && typeAssert.integer(hints.value, 'hints.value is not integer.')) {
+      // eslint-disable-next-line dot-notation
+      this.#config.hints['value'] = new Variant('i', hints.value);
+    }
+
     if ('x' in hints && typeAssert.integer(hints.x, 'hints.x is not integer.')) {
       // eslint-disable-next-line dot-notation
       this.#config.hints['x'] = new Variant('i', hints.x);


### PR DESCRIPTION
urgency=0 means "low". if no urgency hint is set, it defaults to urgency=1, which is "normal". so setting the urgency hint to 0 was actually resulting in a "normal" notification.